### PR TITLE
Address flashloan exploit by adding overestimate flag to inventory

### DIFF
--- a/contracts/AloeBlend.sol
+++ b/contracts/AloeBlend.sol
@@ -178,7 +178,7 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
         silo1.delegate_poke();
 
         (uint160 sqrtPriceX96, , , , , , ) = UNI_POOL.slot0();
-        (uint256 inventory0, uint256 inventory1, ) = _getInventory(primary, limit, sqrtPriceX96);
+        (uint256 inventory0, uint256 inventory1, ) = _getInventory(primary, limit, sqrtPriceX96, true);
         (shares, amount0, amount1) = _computeLPShares(
             totalSupply,
             inventory0,
@@ -318,7 +318,8 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
         (uint256 inventory0, uint256 inventory1, InventoryDetails memory d) = _getInventory(
             primary,
             limit,
-            cache.sqrtPriceX96
+            cache.sqrtPriceX96,
+            false
         );
 
         // Remove the limit order if it exists
@@ -625,7 +626,7 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
     function getInventory() external view returns (uint256 inventory0, uint256 inventory1) {
         (Uniswap.Position memory primary, Uniswap.Position memory limit, , ) = _loadPackedSlot();
         (uint160 sqrtPriceX96, , , , , , ) = UNI_POOL.slot0();
-        (inventory0, inventory1, ) = _getInventory(primary, limit, sqrtPriceX96);
+        (inventory0, inventory1, ) = _getInventory(primary, limit, sqrtPriceX96, false);
     }
 
     struct InventoryDetails {
@@ -644,13 +645,19 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
     /**
      * @notice Estimate's the vault's liabilities to users -- in other words, how much would be paid out if all
      * holders redeemed their LP tokens at once.
-     * @dev Underestimates the true payout unless both silos and Uniswap positions have just been poked. Also
-     * assumes that the maximum amount will accrue to the maintenance budget during the next `rebalance()`. If
-     * it takes less than that for the budget to reach capacity, then the values reported here may increase after
-     * calling `rebalance()`.
+     * @dev Underestimates the true payout unless both silos and Uniswap positions have just been poked. Also...
+     * if _overestimate is false
+     *      Assumes that the maximum amount will accrue to the maintenance budget during the next `rebalance()`. If it
+     *      takes less than that for the budget to reach capacity, then the values reported here may increase after
+     *      calling `rebalance()`.
+     * if _overestimate is true
+     *      Assumes that nothing will accrue to the maintenance budget during the next `rebalance()`. So the values
+     *      reported here may decrease after calling `rebalance()`, i.e. this becomes an overestimate rather than an
+     *      underestimate.
      * @param _primary The primary position
      * @param _limit The limit order; if inactive, `_limit.lower` should equal `_limit.upper`
      * @param _sqrtPriceX96 The current sqrt(price) of the Uniswap pair from `slot0()`
+     * @param _overestimate Whether to error on the side of overestimating or underestimating
      * @return inventory0 The amount of token0 underlying all LP tokens
      * @return inventory1 The amount of token1 underlying all LP tokens
      * @return d A struct containing details that may be relevant to other functions. We return it here to avoid
@@ -659,7 +666,8 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
     function _getInventory(
         Uniswap.Position memory _primary,
         Uniswap.Position memory _limit,
-        uint160 _sqrtPriceX96
+        uint160 _sqrtPriceX96,
+        bool _overestimate
     )
         private
         view
@@ -685,21 +693,21 @@ contract AloeBlend is AloeBlendERC20, UniswapHelper, IAloeBlend {
         a = silo0Basis;
         b = silo0.balanceOf(address(this));
         a = b > a ? (b - a) / MAINTENANCE_FEE : 0; // interest / MAINTENANCE_FEE
-        d.fluid0 += _balance0() + b - a;
+        d.fluid0 += _balance0() + b - (_overestimate ? 0 : a);
 
         // token1 from contract + silo1
         a = silo1Basis;
         b = silo1.balanceOf(address(this));
         a = b > a ? (b - a) / MAINTENANCE_FEE : 0; // interest / MAINTENANCE_FEE
-        d.fluid1 += _balance1() + b - a;
+        d.fluid1 += _balance1() + b - (_overestimate ? 0 : a);
 
         // Primary position; limit order is placed without touching this, so its amounts aren't included in `fluid`
         if (_primary.lower != _primary.upper) {
             (d.primaryLiquidity, , , a, b) = _primary.info();
             (inventory0, inventory1) = _primary.amountsForLiquidity(_sqrtPriceX96, d.primaryLiquidity);
 
-            inventory0 += d.fluid0 + a - a / MAINTENANCE_FEE;
-            inventory1 += d.fluid1 + b - b / MAINTENANCE_FEE;
+            inventory0 += d.fluid0 + a - (_overestimate ? 0 : a / MAINTENANCE_FEE);
+            inventory1 += d.fluid1 + b - (_overestimate ? 0 : b / MAINTENANCE_FEE);
         } else {
             inventory0 = d.fluid0;
             inventory1 = d.fluid1;


### PR DESCRIPTION
There are two ways to reasonably estimate the vault's inventory:
- Assume that rebalances are cheap compared to daily earnings, and the maintenance budget stays full. In this case, we report that the inventory includes 100% of earnings-since-last-rebalance.
- Assume that rebalances are expensive relative to daily earnings. The maintenance budget may still stay full, but in order to make that happen we're contributing a significant chunk of earnings to it (maximum 10%). So we report that the inventory contains only 90% of earnings-since-last-rebalance.

In the `rebalance` function, it is crucial that we either have the true value or an underestimate (because of how some other math works out). Same goes for the `withdraw` function, since we don't want to accidentally give users too much.

However, using the underestimated inventory values in `deposit` is problematic:

1. Exploiter takes out a huge flashloan and deposits to the pool
2. Exploiter calls `rebalance` and (due to current pool state and `rewardPerGas` value) the `maintenanceBudget` gets clipped to its max value in `_rewardCaller`
3. Exploiter withdraws all their shares

In this scenario, it is possible for the exploiter to seize up to 10% of earnings-since-last-rebalance, even though those earnings are *supposed* to be distributed to the pool as a whole (since they're not needed to sustain the maintenance budget). See Desmos for real-world values:

https://www.desmos.com/calculator/zg6lcozrhj

This change fixes this by using the overestimated version of the calculation for `deposit`